### PR TITLE
Quiz 화면 UI 정상화 및 획득 점수 Main Tab에서 확인 가능

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { useState } from 'react';
 import HomePage from './pages/HomePage';
 import QuizMain from './pages/QuizPage/QuizMain';
 import UserPage from './pages/UserPage';
@@ -12,12 +13,15 @@ const App = () => {
   const hideBottomNavPaths = ['/login', '/quiz/screen1', '/quiz/screen2', '/quiz/screen3'];
   const shouldHideBottomNav = hideBottomNavPaths.includes(location.pathname);
 
+  //점수 관리
+  const [score, setScore] = useState<number>(0);
+
   return (
     <>
       <Routes>
         <Route path="/login" element={<LoginPage />} />
-        <Route path="/" element={<HomePage />} />
-        <Route path="/quiz/*" element={<QuizMain />} />
+        <Route path="/" element={<HomePage/>} />
+        <Route path="/quiz/*" element={<QuizMain score={score} setScore={setScore} />} />
         <Route path="/user" element={<UserPage />} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>

--- a/src/pages/QuizPage/QuizMain.tsx
+++ b/src/pages/QuizPage/QuizMain.tsx
@@ -3,9 +3,11 @@ import { Container } from '../../components/common/container/Container';
 import MenuBookIcon from '../../assets/menu_book.svg';
 import { Route, Routes, useNavigate } from 'react-router-dom';
 import QuizManager from './QuizManager';
+import {useEffect} from 'react';
 
 //Quiz 메인 페이지
 function QuizMainContent() {
+
   const navigate = useNavigate(); //버튼 클릭 시 라우팅을 위해 사용
 
   return (
@@ -36,14 +38,21 @@ function QuizMainContent() {
 }
 
 // QuizMain 관련한 컴포넌트 (하위 퀴즈 화면들을 Route로 우선 연결해 놓았습니다)
-function QuizMain() {
+function QuizMain(props: { score: number; setScore: (score: number) => void }) {
+
+  const {score, setScore} = props; //props 객체에서 구조 분해 할당
+  
+  //테스트용 코드
+  useEffect(()=> {
+    console.log('현재 점수는..', score);
+  }, [])
 
   return (
     <Routes>
       <Route path="/" element={<QuizMainContent/>} />
-      <Route path="/screen1" element={<QuizManager/>} />
-      <Route path="/screen2" element={<QuizManager/>} />
-      <Route path="/screen3" element={<QuizManager/>} />
+      <Route path="/screen1" element={<QuizManager score={score} setScore={setScore}/>} />
+      <Route path="/screen2" element={<QuizManager score={score} setScore={setScore}/>} />
+      <Route path="/screen3" element={<QuizManager score={score} setScore={setScore}/>} />
     </Routes>
   );
 }

--- a/src/pages/QuizPage/QuizManager.tsx
+++ b/src/pages/QuizPage/QuizManager.tsx
@@ -5,12 +5,16 @@ import quizData from '../../assets/quizData/quiz.json'; // 상대 경로로 JSON
 
 import {Quiz} from './types';
 
+import { useNavigate } from 'react-router-dom';
+
 
 //퀴즈 데이터를 랜덤화 하여 하위 컴포넌트를 내뱉도록 구현된 QuizManager
 function QuizManager() {
     const [shuffledQuizzes, setShuffledQuizzes] = useState<Quiz[]>([]); //랜덤 문제 목록
     const [currentQuizIndex, setCurrentQuizIndex] = useState<number>(0); //현재 퀴즈 인덱스
     const [score, setScore] = useState<number>(0); //점수 저장 (추후에 전역 state로 사용해야 할 것 같음)
+
+    const navigate = useNavigate(); //버튼 클릭 시 라우팅을 위해 사용
 
     //랜덤하게 인덱스를 선택하는 함수
     const getRandomIndexes = (length: number, count: number) => {
@@ -35,7 +39,6 @@ function QuizManager() {
 
         //정답이면 점수 증가
         if(isCorrect) {
-            console.log("정답이에요")
             setScore((prevScore: number) => prevScore + 10);
         }
 
@@ -45,16 +48,17 @@ function QuizManager() {
         } else {
             //마지막 문제를 푼 경우 결과 표시
             alert(`총 ${score + (isCorrect ? 10 : 0)}점을 획득했습니다!`); //마지막 정답 반영
-            // handleReset(); //초기화 및 메인 화면으로 이동
+            handleReset(); //초기화 및 메인 화면으로 이동
         }
     }
 
     //초기화 함수
-    // const handleReset = () => {
-    //     setShuffledQuizzes([]);
-    //     setCurrentQuizIndex(0);
-    //     setScore(0);
-    // }
+    const handleReset = () => {
+        setShuffledQuizzes([]);
+        setCurrentQuizIndex(0);
+        setScore(0);
+        navigate('/quiz'); //퀴즈 메인으로 이동
+    }
 
     //퀴즈를 rendering하는 메소드 renderQuiz
     const renderQuiz = () => {

--- a/src/pages/QuizPage/QuizManager.tsx
+++ b/src/pages/QuizPage/QuizManager.tsx
@@ -9,10 +9,11 @@ import { useNavigate } from 'react-router-dom';
 
 
 //퀴즈 데이터를 랜덤화 하여 하위 컴포넌트를 내뱉도록 구현된 QuizManager
-function QuizManager() {
+function QuizManager(props: { score: number; setScore: (score: number) => void }) {
     const [shuffledQuizzes, setShuffledQuizzes] = useState<Quiz[]>([]); //랜덤 문제 목록
     const [currentQuizIndex, setCurrentQuizIndex] = useState<number>(0); //현재 퀴즈 인덱스
-    const [score, setScore] = useState<number>(0); //점수 저장 (추후에 전역 state로 사용해야 할 것 같음)
+    const [localScore, setLocalScore] = useState<number>(0); //점수 저장 (추후에 전역 state로 사용해야 할 것 같음)
+    const {score, setScore} = props; //props 객체에서 구조 분해 할당
 
     const navigate = useNavigate(); //버튼 클릭 시 라우팅을 위해 사용
 
@@ -39,7 +40,7 @@ function QuizManager() {
 
         //정답이면 점수 증가
         if(isCorrect) {
-            setScore((prevScore: number) => prevScore + 10);
+            setLocalScore((prevScore: number) => prevScore + 10);
         }
 
         //다음 문제로 이동
@@ -47,7 +48,8 @@ function QuizManager() {
             setCurrentQuizIndex((prevIndex: number) => prevIndex + 1);
         } else {
             //마지막 문제를 푼 경우 결과 표시
-            alert(`총 ${score + (isCorrect ? 10 : 0)}점을 획득했습니다!`); //마지막 정답 반영
+            alert(`총 ${localScore + (isCorrect ? 10 : 0)}점을 획득했습니다!`); //마지막 정답 반영
+            setScore(score+localScore + (isCorrect ? 10 : 0)); //점수 set
             handleReset(); //초기화 및 메인 화면으로 이동
         }
     }
@@ -56,7 +58,7 @@ function QuizManager() {
     const handleReset = () => {
         setShuffledQuizzes([]);
         setCurrentQuizIndex(0);
-        setScore(0);
+        setLocalScore(0);
         navigate('/quiz'); //퀴즈 메인으로 이동
     }
 

--- a/src/pages/QuizPage/QuizScreen1.tsx
+++ b/src/pages/QuizPage/QuizScreen1.tsx
@@ -77,7 +77,9 @@ function QuizScreen1({
       {/* 상단 곡선 배경 */}
       <TopBackground className={selectedAnswer !== null ? 'top-background-animate' : ''}>
         <Title font="Pretendard">{currentQuizIndex+1}/5</Title>
-        <Title color={getTitleTextColor()}>{getTitleText()}</Title>
+        <div style={{maxWidth: '350px'}}>
+          <Title color={getTitleTextColor()}>{getTitleText()}</Title>
+        </div>
       </TopBackground>
       {/* 하단 배경 및 콘텐츠 */}
       <BottomBackground>
@@ -103,15 +105,9 @@ function QuizScreen1({
                   alt={`Option ${option.id}`}
                 />
               ) : (
-                <div
-                  style={{
-                    fontSize: '1.2rem', // 텍스트 크기
-                    fontWeight: 'bold', // 텍스트 굵기
-                    color: '#5a3220', // 텍스트 색상
-                  }}
-                >
+                <span>
                   {option.content}
-                </div>
+                </span>
               )}
               <span className="overlay-text">{option.id}</span> {/* 버튼 상단 ID 표시 */}
             </Button>

--- a/src/pages/QuizPage/quizMain_styles.ts
+++ b/src/pages/QuizPage/quizMain_styles.ts
@@ -39,6 +39,9 @@ export const Title = styled.span`
   font-size: 1.8rem;
   text-align: center;
   font-family: 'LeeSeoyun';
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  white-space: normal; /* 줄바꿈 허용 */
 
   @media screen and (min-width: 1200px) {
     font-size: 2rem;

--- a/src/pages/QuizPage/quizscreen_styles.ts
+++ b/src/pages/QuizPage/quizscreen_styles.ts
@@ -115,7 +115,7 @@ export const Title = styled.h1<{ color?: string; font?: string }>`
 export const Button = styled.button`
   width: 45%; /* 버튼 너비를 45%로 설정해 두 개의 버튼이 가로로 배치되도록 */
   max-width: 200px;
-  height: 300px; /* 고정된 버튼 높이 */
+  height: 270px; /* 고정된 버튼 높이 */
   margin: 8px; /* 간격 조정 */
   font-size: 2rem;
   font-weight: bold;
@@ -129,6 +129,8 @@ export const Button = styled.button`
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  padding-left: 20px;
+  padding-right: 20px;
 
   &.left-correct {
     animation: ${scaleAndShiftRight} 0.5s forwards;
@@ -156,8 +158,8 @@ export const Button = styled.button`
   }
 
   img {
-    width: 100%;
-    height: auto;
+    height: 100%;
+    max-width: 120%;
     object-fit: contain;
   }
 
@@ -165,9 +167,17 @@ export const Button = styled.button`
     font-size: 2rem;
   }
 
+  span {
+    font-size: 1.8rem;
+    font-weight: bold; // 텍스트 굵기
+    color: #5a3220; // 텍스트 색상
+  }
+
   .overlay-text {
-    position: relative;
-    top: -180px;
+    position: absolute; /* Button을 기준으로 고정 */
+    top: -40px;
+    left: 50%;
+    transform: translateX(-50%); /* 가로 중앙 정렬 */
     padding: 5px 10px;
     border-radius: 5px;
     font-size: 2rem;


### PR DESCRIPTION
## 요약
- Quiz 화면의 UI 깨지는 문제를 해결했습니다.
- User가 획득한 점수는 메인에 누적되어 확인이 가능합니다. (App.tsx(최상단 컴포넌트)에서 score를 state로 관리하고 있기에, props로 넘겨서 HomePage.tsx와 UserPage.tsx 등에서 가져다 사용 가능합니다)

이슈 번호 : #12

## 변경 사항
- App.tsx에 score(점수) state 추가 / 이에 따른 점수값 관리 체계 변경
- QuizScreen 관련 스타일(quizscreen_styles.ts) 수정

## 리뷰 요구사항
- App.tsx의 약간의 변화가 있습니다.

## 스크린샷
<br/>
<img width="250" alt="스크린샷 2024-12-07 16 27 32" src="https://github.com/user-attachments/assets/cfff3c65-5b13-479d-a0d9-3948feb0feee">
<img width="250" alt="스크린샷 2024-12-07 16 28 55" src="https://github.com/user-attachments/assets/b9b052ce-a5ab-4ee7-8a3f-dc2dd268e6fb">
<br/>
<img width="294" alt="스크린샷 2024-12-07 16 27 43" src="https://github.com/user-attachments/assets/f85657e8-2303-4250-8e37-2e867235edb3">
<img width="292" alt="스크린샷 2024-12-07 16 27 53" src="https://github.com/user-attachments/assets/40a8fb21-8b4d-478b-8964-110f6ea18408">


---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
