### PR TITLE
오답노트 연계를 위해 점수, 오답문제 관련 state 추가 (localStorage 활용)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { BrowserRouter, Route, Routes, useLocation } from 'react-router-dom';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import HomePage from './pages/HomePage';
 import QuizMain from './pages/QuizPage/QuizMain';
 import UserPage from './pages/UserPage';
@@ -14,14 +14,38 @@ const App = () => {
   const shouldHideBottomNav = hideBottomNavPaths.includes(location.pathname);
 
   //점수 관리
-  const [score, setScore] = useState<number>(0);
+  const [score, setScore] = useState<number>(()=>{
+    const savedScore = localStorage.getItem('score');
+    return savedScore ? JSON.parse(savedScore) : 0; // localStorage에 저장된 값이 없으면 0으로 초기화
+  }); 
+
+  //오답 문제의 ID를 저장
+  const [incorrectQuestionIDs, setIncorrectQuestionIDs] = useState<number[]>(()=>{
+    // 초기값으로 localStorage에서 데이터를 로드
+    const savedIncorrectIDs = localStorage.getItem('incorrectQuestionIDs');
+    return savedIncorrectIDs ? JSON.parse(savedIncorrectIDs) : [];
+  }); 
+  
+  // 점수가 업데이트될 때 localStorage에 저장
+  useEffect(() => {
+    localStorage.setItem('score', JSON.stringify(score));
+  }, [score]);
+
+  // 오답 ID 추가 메소드인 addIncorrectQuestionID
+  const addIncorrectQuestionID = (id: number) => {
+    if (!incorrectQuestionIDs.includes(id)) {
+      const updatedIDs = [...incorrectQuestionIDs, id];
+      setIncorrectQuestionIDs(updatedIDs);
+      localStorage.setItem('incorrectQuestionIDs', JSON.stringify(updatedIDs)); // 업데이트된 데이터를 localStorage에 저장
+    }
+  };
 
   return (
     <>
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/" element={<HomePage/>} />
-        <Route path="/quiz/*" element={<QuizMain score={score} setScore={setScore} />} />
+        <Route path="/quiz/*" element={<QuizMain score={score} setScore={setScore} addInCorrectQuestionID={addIncorrectQuestionID} />} />
         <Route path="/user" element={<UserPage />} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>

--- a/src/pages/QuizPage/QuizMain.tsx
+++ b/src/pages/QuizPage/QuizMain.tsx
@@ -38,9 +38,9 @@ function QuizMainContent() {
 }
 
 // QuizMain 관련한 컴포넌트 (하위 퀴즈 화면들을 Route로 우선 연결해 놓았습니다)
-function QuizMain(props: { score: number; setScore: (score: number) => void }) {
+function QuizMain(props: { score: number; setScore: (score: number) => void; addInCorrectQuestionID: (id:number) => void; }) {
 
-  const {score, setScore} = props; //props 객체에서 구조 분해 할당
+  const {score, setScore, addInCorrectQuestionID} = props; //props 객체에서 구조 분해 할당
   
   //테스트용 코드
   useEffect(()=> {
@@ -50,9 +50,9 @@ function QuizMain(props: { score: number; setScore: (score: number) => void }) {
   return (
     <Routes>
       <Route path="/" element={<QuizMainContent/>} />
-      <Route path="/screen1" element={<QuizManager score={score} setScore={setScore}/>} />
-      <Route path="/screen2" element={<QuizManager score={score} setScore={setScore}/>} />
-      <Route path="/screen3" element={<QuizManager score={score} setScore={setScore}/>} />
+      <Route path="/screen1" element={<QuizManager score={score} setScore={setScore} addInCorrectQuestionID={addInCorrectQuestionID}/>} />
+      <Route path="/screen2" element={<QuizManager score={score} setScore={setScore} addInCorrectQuestionID={addInCorrectQuestionID}/>} />
+      <Route path="/screen3" element={<QuizManager score={score} setScore={setScore} addInCorrectQuestionID={addInCorrectQuestionID}/>} />
     </Routes>
   );
 }

--- a/src/pages/QuizPage/QuizManager.tsx
+++ b/src/pages/QuizPage/QuizManager.tsx
@@ -9,11 +9,11 @@ import { useNavigate } from 'react-router-dom';
 
 
 //퀴즈 데이터를 랜덤화 하여 하위 컴포넌트를 내뱉도록 구현된 QuizManager
-function QuizManager(props: { score: number; setScore: (score: number) => void }) {
+function QuizManager(props: { score: number; setScore: (score: number) => void; addInCorrectQuestionID: (id:number) => void; }) {
     const [shuffledQuizzes, setShuffledQuizzes] = useState<Quiz[]>([]); //랜덤 문제 목록
     const [currentQuizIndex, setCurrentQuizIndex] = useState<number>(0); //현재 퀴즈 인덱스
     const [localScore, setLocalScore] = useState<number>(0); //점수 저장 (추후에 전역 state로 사용해야 할 것 같음)
-    const {score, setScore} = props; //props 객체에서 구조 분해 할당
+    const {score, setScore, addInCorrectQuestionID} = props; //props 객체에서 구조 분해 할당
 
     const navigate = useNavigate(); //버튼 클릭 시 라우팅을 위해 사용
 
@@ -36,11 +36,14 @@ function QuizManager(props: { score: number; setScore: (score: number) => void }
 
     //정답 처리 함수
     const handleNext = (isCorrect: boolean) => {
-        console.log("handleNext 수행, currentQuizIndex: ", currentQuizIndex);
-
         //정답이면 점수 증가
         if(isCorrect) {
             setLocalScore((prevScore: number) => prevScore + 10);
+        }
+
+        //오답이면 해당 문제의 id 추가
+        if(!isCorrect) {
+            addInCorrectQuestionID(shuffledQuizzes[currentQuizIndex].id); 
         }
 
         //다음 문제로 이동


### PR DESCRIPTION
## 요약
- 오답노트 연계를 위해 App.tsx에 오답 문제 ID를 관리하는 state 추가 (새로고침을 해도 값 유지를 위해 localStorage 활용)
- 오답노트 개발 시에 quiz.json에 있는 데이터와 오답 문제 ID를 관리하는 state(incorrectQuestionIDs)를 연계하면 금방 개발하실 수 있습니다. (UI는 QuizScreen의 기본 UI 활용)


이슈 번호 : #13

## 변경 사항
- App.tsx에 state 2가지 추가 (score, inCorrectQuestionIDs)
- 이에 따른 state 메소드 변경 (localStorage 연계를 통해 브라우저에 영구 저장)

## 리뷰 요구사항
- App.tsx에 변화가 있습니다.

## 스크린샷
<img width="400" alt="스크린샷 2024-12-07 18 27 07" src="https://github.com/user-attachments/assets/9452ecd6-20cd-4cf6-b1bb-badcaa7d5ff0">

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
